### PR TITLE
add support button for mobile screens which opens hamburger menu

### DIFF
--- a/src/Components/GlobalNavBar.js
+++ b/src/Components/GlobalNavBar.js
@@ -101,10 +101,10 @@ function GlobalNavBar() {
 
   return (
   <>
-    <AppBar color="secondary" elevation={0} position="sticky">
-      <Accordion expanded={isAccordionExpanded} elevation={0} sx={{ display:{ xs:'block', sm:'none'} }}>
-        <AccordionSummary expandIcon={accordionIconIsClose ? <CloseIcon onClick={() => handleAccordion()} /> : <MenuIcon onClick={() => handleAccordion()} />} >
-          <Typography color={grey[400]} sx={{ fontWeight: 'bold', textDecoration: "none" }} variant="h6">
+    <AppBar color="secondary" elevation={0} position="sticky" sx={{display:{ xs:'flex', sm:'none'}}}>
+      <Accordion expanded={isAccordionExpanded} elevation={0}>
+        <AccordionSummary expandIcon={accordionIconIsClose ? <CloseIcon onClick={() => handleAccordion()} /> : <MenuIcon onClick={() => handleAccordion()} />}>
+        <Typography color={grey[400]} sx={{ fontWeight: 'bold', textDecoration: "none", alignSelf:'center'}} variant="h6">
             Cage Free Hub
           </Typography>
           <Box bgcolor='primary.main' sx={{ ...styles.betaBox }}>
@@ -112,6 +112,18 @@ function GlobalNavBar() {
               Beta
             </Typography>
           </Box>
+          <Box sx={{ flexGrow: 1 }}/>
+          <Button size="square"
+          onClick={() => handleAccordion()}
+          style={{
+            backgroundColor:'#EFFAF9', 
+            color:'#3FAB94',  
+            border:'0',
+            alignSelf:'center'
+          }}
+          sx={{marginRight:2}}>
+            <HelpOutlineIcon fontSize='support_icon'/>
+          </Button>
         </AccordionSummary>
         <List>
           <ListItem button component={Link} to="/login" onClick={() => handleAccordion()} sx={{ display: currentUser ? 'none' : 'block' }}>

--- a/src/Components/Theme.js
+++ b/src/Components/Theme.js
@@ -1,5 +1,20 @@
 
 const Theme = {
+  components: {
+    MuiButton: {
+      variants: [
+        {
+          props: { size: 'square' },
+          style: {
+            maxWidth: '32px', 
+            maxHeight: '32px', 
+            minWidth: '32px', 
+            minHeight: '32px'
+          },
+        },
+      ],
+    }
+  },
   palette: {
     primary: {
       light: '#EFFAF9',
@@ -42,6 +57,9 @@ const Theme = {
       fontWeight: 700,
       fontSize: 14,
       color: '#1B2B3E',
+    },
+    support_icon:{
+      fontSize: 12
     },
     p_large: {
       fontWeight: 400,


### PR DESCRIPTION
Added the support button to smaller/mobile screens. When clicked, it acts the same as the hamburger menu. The Figma button seemed to be 32x32px with a 12px ? symbol, so I added a size variant in theme.js

<details>
<summary>changes photo</summary>
<img width="560" alt="mobile suport button" src="https://user-images.githubusercontent.com/59973863/199874510-b431afa7-64d8-4a31-b8fb-d5e9676375f4.png">
clicked:
<img width="641" alt="mobile support clicked" src="https://user-images.githubusercontent.com/59973863/199874517-01967a8c-969f-4afc-9cc6-ba253f0265d2.png">
</details>

