### PR TITLE
Fix translation strings flashing on page load

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -11,8 +11,8 @@ i18n
   .init({
     ...(stage === Stage.DEV ? {} : {fallbackLng: 'en'}),
     //lng: 'th', // Set the default language here
-    react: { 
-      useSuspense: false //   <---- this will do the magic
+    react: {
+      useSuspense: true // Wait for translations to load before rendering
     },
     interpolation: {
       escapeValue: false, // not needed for react as it escapes by default

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,19 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import './i18n';
 import reportWebVitals from './reportWebVitals';
 import {BrowserRouter} from "react-router-dom"
+import Loading from './Components/Loading';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <BrowserRouter>
     <React.StrictMode>
-      <App />
+      <Suspense fallback={<Loading />}>
+        <App />
+      </Suspense>
     </React.StrictMode>
   </BrowserRouter>
 );


### PR DESCRIPTION
Enable React Suspense for i18n to prevent translation keys from flashing before the actual translations load. This ensures a smoother user experience by showing a loading spinner while translations are being fetched.

Changes:
- Enable useSuspense in i18n configuration (src/i18n.js)
- Wrap App with Suspense boundary and Loading fallback (src/index.js)